### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -20,7 +20,7 @@ define('KEYWORD_SOURCE_SYNTAX', 'syntax');
 
 class action_plugin_description extends DokuWiki_Action_Plugin {
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT','BEFORE',$this,'description',array());
     }
 

--- a/syntax.php
+++ b/syntax.php
@@ -25,14 +25,14 @@ class syntax_plugin_description extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('\{\{description>.+?\}\}', $mode, 'plugin_description');
     }
 
-    function handle($match, $state, $pos, &$handler) {
+    function handle($match, $state, $pos, Doku_Handler $handler) {
         $match = substr($match, 14, -2); // strip markup
         $match = hsc($match);
         
         return array($match);
     }            
 
-    function render($mode, &$renderer, $data) {
+    function render($mode, Doku_Renderer $renderer, $data) {
         global $conf;
         global $ID;       
         $description = $data[0];


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.